### PR TITLE
Add sbt version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: scala
 sudo: false
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,9 @@ before_install:
 script:
   - "export SPARK_CONF_DIR=./log4j/"
   - sbt clean coverage compile package assembly test || (rm -rf ~/.ivy2 ~/.m2 && sbt clean coverage compile package test)
-  - "[ -f spark] || mkdir spark && cd spark && axel http://d3kbcqa49mib13.cloudfront.net/spark-2.1.0-bin-hadoop2.7.tgz && cd .."
-  - "tar -xf ./spark/spark-2.1.0-bin-hadoop2.7.tgz"
-  - "export SPARK_HOME=`pwd`/spark-2.1.0-bin-hadoop2.7"
+  - "[ -f spark] || mkdir spark && cd spark && axel http://d3kbcqa49mib13.cloudfront.net/spark-2.2.0-bin-hadoop2.7.tgz && cd .."
+  - "tar -xf ./spark/spark-2.2.0-bin-hadoop2.7.tgz"
+  - "export SPARK_HOME=`pwd`/spark-2.2.0-bin-hadoop2.7"
   - "export PYTHONPATH=$SPARK_HOME/python:`ls -1 $SPARK_HOME/python/lib/py4j-*-src.zip`:$PYTHONPATH"
   - "PYSPARK_SUBMIT_ARGS='--jars ./target/examples-assembly-0.0.1.jar pyspark-shell' nosetests --with-doctest --doctest-options=+ELLIPSIS --logging-level=INFO --detailed-errors --verbosity=2 --with-coverage --cover-html-dir=./htmlcov"
   - # $SPARK_HOME/bin/spark-submit ./src/main/r/wc.R $SPARK_HOME/README.md

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ parallelExecution in Test := false
 
 fork := true
 
-javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:MaxPermSize=2048M", "-XX:+CMSClassUnloadingEnabled", "-Djna.nosys=true")
+javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:+CMSClassUnloadingEnabled", "-Djna.nosys=true")
 
 // additional libraries
 libraryDependencies ++= Seq(

--- a/build_windows.sbt
+++ b/build_windows.sbt
@@ -32,7 +32,7 @@ parallelExecution in Test := false
 
 fork := true
 
-javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:MaxPermSize=2048M", "-XX:+CMSClassUnloadingEnabled", "-Djna.nosys=true")
+javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:+CMSClassUnloadingEnabled", "-Djna.nosys=true")
 
 // additional libraries
 libraryDependencies ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.18


### PR DESCRIPTION
* Add default sbt version. Otherwise, IntelliJ will generate the latest version of `build.properties` then it will fail to recognize this project.
* Synchronize Spark version at Travis CI with `build.sbt`