### PR TITLE
Fall back to archive DLs

### DIFF
--- a/env_setup.sh
+++ b/env_setup.sh
@@ -12,11 +12,12 @@ SPARK_FILE="spark-${SPARK_VERSION}-bin-hadoop3.tgz"
 ICEBERG_VERSION=${ICEBERG_VERSION:-"1.4.0"}
 if [ ! -f "${SPARK_FILE}" ]; then
   SPARK_DIST_URL="https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/${SPARK_FILE}"
+  SPARK_ARCHIVE_DIST_URL="https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/${SPARK_FILE}"
   if command -v axel &> /dev/null
   then
-    axel "$SPARK_DIST_URL" &
+    (axel "$SPARK_DIST_URL" || axel "$SPARK_ARCHIVE_DIST_URL") &
   else
-    wget "$SPARK_DIST_URL" &
+    (wget "$SPARK_DIST_URL" || wget "$SPARK_ARCHIVE_DIST_URL") &
   fi
 fi
 # Download Icberg if not present


### PR DESCRIPTION
When new Spark releases come out our old versions may go away and we should fall back to the "archive" in those cases.