### PR TITLE
Verify filter pushdown through dataset typing

### DIFF
--- a/core/src/test/scala/com/high-performance-spark-examples/dataframe/PandaPlaceFilterPushdown.scala
+++ b/core/src/test/scala/com/high-performance-spark-examples/dataframe/PandaPlaceFilterPushdown.scala
@@ -18,19 +18,31 @@ import com.holdenkarau.spark.testing._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers._
 
+case class ExtraMagic(
+  place: String,
+  pandaType: String,
+  happyPandas: Integer,
+  totalPandas: Integer,
+  extraInfo: Integer)
+
+
 class PandaPlaceFilterPushdown extends AnyFunSuite with DataFrameSuiteBase {
 
   override def appName: String = "pandaPlaceFilterPushdown"
 
   val basicList = List(
-    ("a", "b", 1, 2))
+    ExtraMagic("a", "b", 1, 2, 3),
+    ExtraMagic("toronto", "b", 1, 2, 3),
+  )
 
   test("simpleFilterTest") {
     val sqlCtx = sqlContext
     import sqlCtx.implicits._
     val inputDF = sqlCtx.createDataFrame(basicList)
+    val restrictedDF = inputDF.select($"place", $"pandaType", $"happyPandas", $"totalPandas")
     val switched = inputDF.as[PandaInfo]
-    val filtered = switched.filter(_.city === "a")
+    // Note if we write the filter with functional syntax it does not push down.
+    val filtered = switched.filter($"place" === "a")
     assert(filtered.count() === 1)
   }
 }

--- a/core/src/test/scala/com/high-performance-spark-examples/dataframe/PandaPlaceFilterPushdown.scala
+++ b/core/src/test/scala/com/high-performance-spark-examples/dataframe/PandaPlaceFilterPushdown.scala
@@ -1,0 +1,36 @@
+/**
+ * Happy Panda Example for DataFrames.
+ * Computes the % of happy pandas. Very contrived.
+ */
+package com.highperformancespark.examples.dataframe
+
+import scala.collection.mutable
+import scala.util.Random
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.{SQLContext, SparkSession}
+import org.apache.spark.sql.types._
+
+import com.highperformancespark.examples.dataframe.HappyPandas.PandaInfo
+import com.highperformancespark.examples.dataframe.HappyPandas.Pandas
+import com.holdenkarau.spark.testing._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers._
+
+class PandaPlaceFilterPushdown extends AnyFunSuite with DataFrameSuiteBase {
+
+  override def appName: String = "pandaPlaceFilterPushdown"
+
+  val basicList = List(
+    ("a", "b", 1, 2))
+
+  test("simpleFilterTest") {
+    val sqlCtx = sqlContext
+    import sqlCtx.implicits._
+    val inputDF = sqlCtx.createDataFrame(basicList)
+    val switched = inputDF.as[PandaInfo]
+    val filtered = switched.filter(_.city === "a")
+    assert(filtered.count() === 1)
+  }
+}


### PR DESCRIPTION
Quick example that shows we still push the filter down to the datasourcev2 relation even with an as[] in the middle. Figured I'd add this since there was a blog post a thing about how Spark had problems with this awhile ago and some folks might still be avoiding typed datasets as a result.